### PR TITLE
Update README: use kmail instead of localslackirc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Requirements
 * python3.8
 * chromium
 * kmail
+* gpg

--- a/README.md
+++ b/README.md
@@ -13,5 +13,4 @@ Requirements
 
 * python3.8
 * chromium
-* gpg
-* localslackirc
+* kmail


### PR DESCRIPTION
This PR updates the README to list kmail as a requirement instead of localslackirc.